### PR TITLE
Small unit fixes

### DIFF
--- a/plasmoid/contents/ui/Weather.qml
+++ b/plasmoid/contents/ui/Weather.qml
@@ -103,19 +103,19 @@ Item {
 
         PlasmaComponents.Label {
             id: firstDetail
-            text: i18n("Feels like") + ": " + backend.m_windChill + "°" + backend.m_unitTemperature + "<br />" + i18n("Visibility") + ": " + (backend.m_atmosphereVisibility ? backend.m_atmosphereVisibility + backend.m_unitDistance : i18n("NULL"))
+            text: i18n("Feels like") + ": " + backend.m_windChill + "°" + backend.m_unitTemperature + "<br />" + i18n("Visibility") + ": " + (backend.m_atmosphereVisibility ? backend.m_atmosphereVisibility + ' ' + backend.m_unitDistance : i18n("NULL"))
             font: theme.defaultFont
         }
 
         PlasmaComponents.Label {
             id: secondDetail
-            text: i18n("Humidity") + ": " + backend.m_atmosphereHumidity + "%<br />" + i18n("Pressure") + ": " + backend.m_atmospherePressure + backend.m_unitPressure
+            text: i18n("Humidity") + ": " + backend.m_atmosphereHumidity + "%<br />" + i18n("Pressure") + ": " + backend.m_atmospherePressure + ' ' + backend.m_unitPressure
             font: theme.defaultFont
         }
 
         PlasmaComponents.Label {
             id: thirdDetail
-            text: i18n("UV Index") + ": " + backend.m_atmosphereRising + "<br />" + i18n("Wind") + ": " + backend.m_windSpeed + backend.m_unitSpeed
+            text: i18n("UV Index") + ": " + backend.m_atmosphereRising + "<br />" + i18n("Wind") + ": " + backend.m_windSpeed + ' ' + backend.m_unitSpeed
             font: theme.defaultFont
         }
     }

--- a/plasmoid/contents/ui/Yahoo.qml
+++ b/plasmoid/contents/ui/Yahoo.qml
@@ -205,7 +205,7 @@ Item {
             m_unitPressure = "atm"
         } else if (plasmoid.configuration.pa) {
             m_atmospherePressure = inToPascal(m_atmospherePressure)
-            m_unitPressure = "pa"
+            m_unitPressure = "Pa"
         } else {
             m_atmospherePressure = (m_atmospherePressure * 1.0).toFixed(2) // Need for yahoo bug fix I think
             m_unitPressure = "inHg"


### PR DESCRIPTION
1. put a space between number and unit
2. correctly spell pascal unit

Note: Space is not needed/required between number and `°`.

References #20
