### PR TITLE
Wind direction backend

### DIFF
--- a/plasmoid/contents/ui/Yahoo.qml
+++ b/plasmoid/contents/ui/Yahoo.qml
@@ -441,39 +441,39 @@ Item {
         if (d == 0) {
             return " "
         } else if (0 <= d && d < 11.25) {
-            return "⭡ N"
+            return "⭣ N"
         } else if (11.25 <= d && d < 33.75) {
-            return "⭎ NNE"
+            return "⭩ NNE"
         } else if (33.75 <= d && d < 56.25) {
-            return "⭧ NE"
+            return "⭩ NE"
         } else if (56.25 <= d && d < 78.75) {
-            return "⭧ ENE"
+            return "⭩ ENE"
         } else if (78.75 <= d && d < 101.25) {
-            return "⭢ E"
+            return "⭠ E"
         } else if (101.25 <= d && d < 123.75) {
-            return "⭨ ESE"
+            return "⭦ ESE"
         } else if (123.75 <= d && d < 146.25) {
-            return "⭨ SE"
+            return "⭦ SE"
         } else if (146.25 <= d && d < 168.75) {
-            return "⭏ SSE"
+            return "⭦ SSE"
         } else if (168.75 <= d && d < 191.25) {
-            return "⭣ S"
+            return "⭡ S"
         } else if (191.25 <= d && d < 213.75) {
-            return "⭩ SSW"
+            return "⭎ SSW"
         } else if (213.75 <= d && d < 236.25) {
-            return "⭩ SW"
+            return "⭧ SW"
         } else if (236.25 <= d && d < 258.75) {
-            return "⭩ WSW"
+            return "⭧ WSW"
         } else if (258.75 <= d && d < 281.25) {
-            return "⭠ W"
+            return "⭢ W"
         } else if (281.25 <= d && d < 303.75) {
-            return "⭦ WNW"
+            return "⭨ WNW"
         } else if (303.75 <= d && d < 326.25) {
-            return "⭦ NW"
+            return "⭨ NW"
         } else if (326.25 <= d && d < 348.75) {
-            return "⭦ NNW"
+            return "⭏ NNW"
         } else if (348.75 <= d && d < 360) {
-            return "⭡ N"
+            return "⭣ N"
         } else if (d == 990) {
             return "⥀"
         } else {

--- a/plasmoid/contents/ui/Yahoo.qml
+++ b/plasmoid/contents/ui/Yahoo.qml
@@ -438,44 +438,44 @@ Item {
     }
 
     function parseWind(d) {
-        if (d = 0) {
+        if (d == 0) {
             return " "
         } else if (0 <= d && d < 11.25) {
-            return "N"
+            return "⭡ N"
         } else if (11.25 <= d && d < 33.75) {
-            return "NNE"
+            return "⭎ NNE"
         } else if (33.75 <= d && d < 56.25) {
-            return "NE"
+            return "⭧ NE"
         } else if (56.25 <= d && d < 78.75) {
-            return "ENE"
+            return "⭧ ENE"
         } else if (78.75 <= d && d < 101.25) {
-            return "E"
+            return "⭢ E"
         } else if (101.25 <= d && d < 123.75) {
-            return "ESE"
+            return "⭨ ESE"
         } else if (123.75 <= d && d < 146.25) {
-            return "SE"
+            return "⭨ SE"
         } else if (146.25 <= d && d < 168.75) {
-            return "SSE"
+            return "⭏ SSE"
         } else if (168.75 <= d && d < 191.25) {
-            return "S"
+            return "⭣ S"
         } else if (191.25 <= d && d < 213.75) {
-            return "SSW"
+            return "⭩ SSW"
         } else if (213.75 <= d && d < 236.25) {
-            return "SW"
+            return "⭩ SW"
         } else if (236.25 <= d && d < 258.75) {
-            return "WSW"
+            return "⭩ WSW"
         } else if (258.75 <= d && d < 281.25) {
-            return "W"
+            return "⭠ W"
         } else if (281.25 <= d && d < 303.75) {
-            return "WNW"
+            return "⭦ WNW"
         } else if (303.75 <= d && d < 326.25) {
-            return "NW"
+            return "⭦ NW"
         } else if (326.25 <= d && d < 348.75) {
-            return "NNW"
+            return "⭦ NNW"
         } else if (348.75 <= d && d < 360) {
-            return "N"
-        } else if (d = 990) {
-            return i18n("variable")
+            return "⭡ N"
+        } else if (d == 990) {
+            return "⥀"
         } else {
             return " "
         }

--- a/plasmoid/contents/ui/Yahoo.qml
+++ b/plasmoid/contents/ui/Yahoo.qml
@@ -160,7 +160,7 @@ Item {
         m_unitDistance       = results.units.distance
         m_unitPressure       = results.units.pressure
         m_windChill          = results.wind.chill
-        m_windDirection      = results.wind.direction
+        m_windDirection      = parseWind(results.wind.direction)
         m_windSpeed          = results.wind.speed
         m_atmosphereHumidity     = results.atmosphere.humidity
         m_atmosphereVisibility   = results.atmosphere.visibility
@@ -436,7 +436,51 @@ Item {
                 return i18n("Not Available")
         }
     }
-    
+
+    function parseWind(d) {
+        if (d = 0) {
+            return " "
+        } else if (0 <= d && d < 11.25) {
+            return "N"
+        } else if (11.25 <= d && d < 33.75) {
+            return "NNE"
+        } else if (33.75 <= d && d < 56.25) {
+            return "NE"
+        } else if (56.25 <= d && d < 78.75) {
+            return "ENE"
+        } else if (78.75 <= d && d < 101.25) {
+            return "E"
+        } else if (101.25 <= d && d < 123.75) {
+            return "ESE"
+        } else if (123.75 <= d && d < 146.25) {
+            return "SE"
+        } else if (146.25 <= d && d < 168.75) {
+            return "SSE"
+        } else if (168.75 <= d && d < 191.25) {
+            return "S"
+        } else if (191.25 <= d && d < 213.75) {
+            return "SSW"
+        } else if (213.75 <= d && d < 236.25) {
+            return "SW"
+        } else if (236.25 <= d && d < 258.75) {
+            return "WSW"
+        } else if (258.75 <= d && d < 281.25) {
+            return "W"
+        } else if (281.25 <= d && d < 303.75) {
+            return "WNW"
+        } else if (303.75 <= d && d < 326.25) {
+            return "NW"
+        } else if (326.25 <= d && d < 348.75) {
+            return "NNW"
+        } else if (348.75 <= d && d < 360) {
+            return "N"
+        } else if (d = 990) {
+            return i18n("variable")
+        } else {
+            return " "
+        }
+    }
+
     // convert fahrenheit to celsius
     function fahrenheitToCelsius(f) {
         if (!f) {


### PR DESCRIPTION
Added `parseWind` function which turns wind direction codes to labels with arrow.

So, for example, if the code is 350, it means wind is blowing from north, hence the label "⭣ N".

This doesn't add anything to ui yet.
