### PR TITLE
Re #48: Fix bugs regarding query retries, bad WOEID detection and 24-…

### DIFF
--- a/plasmoid/contents/ui/Weather.qml
+++ b/plasmoid/contents/ui/Weather.qml
@@ -24,7 +24,7 @@ Item {
     Yahoo {
         id: backend
     }
-    
+
     property alias hasdata: backend.hasdata
     property alias errstring: backend.errstring
     property alias m_isbusy: backend.m_isbusy
@@ -45,7 +45,7 @@ Item {
         tooltip: i18n("Refresh")
         onClicked: action_reload()
     }
-    
+
     PlasmaComponents.Label {
         //top-right
         id: yahoo_n_date
@@ -68,7 +68,7 @@ Item {
             id: conditionCol
             width: parent.width / 2
             height: parent.height
-            
+
             PlasmaComponents.Label {
                 id: conditiontemp
                 text: backend.m_conditionTemp + "°" + backend.m_unitTemperature
@@ -119,7 +119,7 @@ Item {
             font: theme.defaultFont
         }
     }
-    
+
     ListView {
         id: forecastView
         visible: hasdata
@@ -137,17 +137,22 @@ Item {
         anchors { horizontalCenter: parent.horizontalCenter; verticalCenter: parent.verticalCenter }
 
         PlasmaCore.IconItem {
-            visible: !(hasdata || m_isbusy)
+            visible: (!(hasdata || m_isbusy)) || backend.networkError
             source: "dialog-error"
             width: theme.mediumIconSize
             height: width
         }
 
         PlasmaComponents.Label {
-            visible: !(hasdata || m_isbusy)
+            visible: (!(hasdata || m_isbusy)) || backend.networkError
             text: errstring ? errstring : i18n("Unknown Error.")
             wrapMode: Text.WordWrap
         }
+    }
+
+    Row {
+        spacing: units.gridUnit
+        anchors { horizontalCenter: parent.horizontalCenter; verticalCenter: parent.verticalCenter }
 
         PlasmaComponents.BusyIndicator {
             visible: m_isbusy
@@ -181,12 +186,12 @@ Item {
         repeat: true
         onTriggered: action_reload()
     }
-    
+
     function action_reload () {
         backend.query()
         iconUpdater.running = true
     }
-    
+
     Connections {
         target: plasmoid.configuration
         onWoeidChanged: action_reload()


### PR DESCRIPTION
…hr display
1. Query fails doesn't display error message in widget. E.g., if network
   down, only see spinning busy thing with no other indication of the problem.
   Now see spinner over the errstring message and retries continue every 10
   seconds in background.
2. When network brought up with widget running, sometimes "readystate"
   gets stuck at 1 and never goes to 4 (DONE) and further query retries don't
   occur.
3. Typo at one place where resObj was "resOjb". Code never executes naturally.
4. If good WOEID (2472005) changed to bad WOEID (247200566) a problem
   was not detected because query.count is 1 but still don't have a full
   response that can be parsed. Must do check to make sure when
   count is 1 that there is a actually a parsable response.
5. Fix potential bug in new 24-hr display code. Problem not seen
   with current format from yahoo. Also, clean up 24-hr code and comments
   some with no functional impact.
