### PR TITLE
Re #48: Fix bugs regarding query retries, bad WOEID detection and 24-…

### DIFF
--- a/plasmoid/contents/ui/Weather.qml
+++ b/plasmoid/contents/ui/Weather.qml
@@ -137,17 +137,22 @@ Item {
         anchors { horizontalCenter: parent.horizontalCenter; verticalCenter: parent.verticalCenter }
 
         PlasmaCore.IconItem {
-            visible: !(hasdata || m_isbusy)
+            visible: (!(hasdata || m_isbusy)) || backend.networkError
             source: "dialog-error"
             width: theme.mediumIconSize
             height: width
         }
 
         PlasmaComponents.Label {
-            visible: !(hasdata || m_isbusy)
+            visible: (!(hasdata || m_isbusy)) || backend.networkError
             text: errstring ? errstring : i18n("Unknown Error.")
             wrapMode: Text.WordWrap
         }
+    }
+
+    Row {
+        spacing: units.gridUnit
+        anchors { horizontalCenter: parent.horizontalCenter; verticalCenter: parent.verticalCenter }
 
         PlasmaComponents.BusyIndicator {
             visible: m_isbusy


### PR DESCRIPTION
…hr display
1. Query failures don't display network error message in widget. E.g., if network
   down, only see spinning busy thing with no other indication of the problem.
   Now see spinner over the errstring message and retries continue every 10
   seconds in background. To avoid transient errors indication (e.g., after
   reboot or when network goes down for very short time) don't display
   errstring until 5 retries occur which is about 50 seconds.
2. When network brought up with widget running, sometimes "readystate"
   gets stuck at 1 and never goes to 4 (DONE) and further query retries don't
   occur and no weather data appears.
3. Typo at one place where resObj was "resOjb". This code never executes
   naturally.
4. If good WOEID (2472005) changed to bad WOEID (247200566) a problem
   not detected because query.count is 1 but still don't have a full
   response that can be parsed. Must do check to make sure when
   count is 1 that there is a actually a parsable response.
5. Fix potential bug in new 24-hr display code. Problem not seen
   with current format from yahoo. Also, clean up 24-hr code and comments
   some with no functional impact.
