### PR TITLE
Re: #41: Change forecast lo~hi to row of hi above row of lo.

### DIFF
--- a/plasmoid/contents/ui/Forecast.qml
+++ b/plasmoid/contents/ui/Forecast.qml
@@ -14,7 +14,8 @@ import QtQml.Models 2.1
 ListModel {
     ListElement {
         day: ""
-        temp: ""
         icon: "weather-none-available"
+        tempHi: ""
+        tempLo: ""
     }
 }

--- a/plasmoid/contents/ui/ForecastDelegate.qml
+++ b/plasmoid/contents/ui/ForecastDelegate.qml
@@ -12,26 +12,37 @@ import QtQuick 2.2
 import org.kde.plasma.core 2.0 as PlasmaCore
 import org.kde.plasma.components 2.0 as PlasmaComponents
 
-Column {
+Item {
     id: delegate
-    spacing: units.gridUnit
     
     PlasmaComponents.Label {
         text: day
+        id: dayId
         anchors.horizontalCenter: parent.horizontalCenter
         font: theme.defaultFont
     }
     
     PlasmaCore.IconItem {
         source: icon
+        id: iconId
         width: theme.smallMediumIconSize
         height: width
-        anchors.horizontalCenter: parent.horizontalCenter
+        anchors {horizontalCenter: parent.horizontalCenter;
+                 top: dayId.bottom; topMargin: units.gridUnit}
     }
     
     PlasmaComponents.Label {
-        text: temp
-        anchors.horizontalCenter: parent.horizontalCenter
+        text: tempHi
+        id: tempHiId
+        anchors {horizontalCenter: parent.horizontalCenter; 
+                 top: iconId.bottom; topMargin: units.gridUnit}
+        font: theme.defaultFont
+    }
+
+    PlasmaComponents.Label {
+        text: tempLo
+        anchors {horizontalCenter: parent.horizontalCenter; 
+                 top: tempHiId.bottom; topMargin: -units.gridUnit/2}
         font: theme.defaultFont
     }
 }

--- a/plasmoid/contents/ui/Yahoo.qml
+++ b/plasmoid/contents/ui/Yahoo.qml
@@ -223,7 +223,8 @@ Item {
 
             forecastModel.append({
                 "day": parseDay(forecasts[i].day),
-                "temp": low + "~" + high + "°" + m_unitTemperature,
+                "tempHi": high + "°" + m_unitTemperature,
+                "tempLo": low  + "°" + m_unitTemperature,
                 "icon": determineIcon(parseInt(forecasts[i].code))
             })
         }


### PR DESCRIPTION
Change ForecastDelegate.qml from "Column" to "Item" so each element
can be independently positioned. This avoids too large spacing
between the row of High forecast temperatures and the row of Lows.
This also changes the "temp" string in Forecast.qml list model to
two separate strings "tempHi" and "tempLo" that are placed on their
own row on the widget (instead of on same row separted by a
tilde).
