### PR TITLE
Re #41: Put forecast hi and low on separate lines.

### DIFF
--- a/plasmoid/contents/ui/Forecast.qml
+++ b/plasmoid/contents/ui/Forecast.qml
@@ -14,7 +14,8 @@ import QtQml.Models 2.1
 ListModel {
     ListElement {
         day: ""
-        temp: ""
+        tempHi: ""
+        tempLo: ""
         icon: "weather-none-available"
     }
 }

--- a/plasmoid/contents/ui/ForecastDelegate.qml
+++ b/plasmoid/contents/ui/ForecastDelegate.qml
@@ -30,7 +30,13 @@ Column {
     }
     
     PlasmaComponents.Label {
-        text: temp
+        text: tempHi
+        anchors.horizontalCenter: parent.horizontalCenter
+        font: theme.defaultFont
+    }
+
+    PlasmaComponents.Label {
+        text: tempLo
         anchors.horizontalCenter: parent.horizontalCenter
         font: theme.defaultFont
     }

--- a/plasmoid/contents/ui/Yahoo.qml
+++ b/plasmoid/contents/ui/Yahoo.qml
@@ -230,7 +230,8 @@ Item {
 
             forecastModel.append({
                 "day": parseDay(forecasts[i].day),
-                "temp": low + "~" + high + "°" + m_unitTemperature,
+                "tempHi": high + "°" + m_unitTemperature,
+                "tempLo": low  + "°" + m_unitTemperature,
                 "icon": determineIcon(parseInt(forecasts[i].code))
             })
         }


### PR DESCRIPTION
Would prefer closer spacing between hi and low lines
similar to spacing between "Sunrise" and "Sunset" text but
can't seem to vary the spacing since day, icon, hi and lo are
all in the same "Column".
