### PR TITLE
Re #59: This allows the user to adjust the widget size for panel.

### DIFF
--- a/plasmoid/contents/config/main.xml
+++ b/plasmoid/contents/config/main.xml
@@ -11,6 +11,12 @@
         <entry name="interval" type="Int">
             <default>60</default>
         </entry>
+        <entry name="widthDelta" type="Int">
+            <default>0</default>
+        </entry>
+        <entry name="heightDelta" type="Int">
+            <default>0</default>
+        </entry>
         <entry name="timeFormat24" type="Bool">
             <default>false</default>
         </entry>

--- a/plasmoid/contents/ui/ConfigGeneral.qml
+++ b/plasmoid/contents/ui/ConfigGeneral.qml
@@ -20,6 +20,8 @@ Item {
     property alias cfg_woeid: woeidField.text
     property alias cfg_interval: intervalField.text
     property alias cfg_timeFormat24: timeFormat24Field.checked
+    property alias cfg_widthDelta: widthDeltaField.text
+    property alias cfg_heightDelta: heightDeltaField.text
 
     ColumnLayout {
         ColumnLayout {
@@ -42,7 +44,7 @@ Item {
                 text: " "
             }
             Label {
-                text: i18n("Update Interval")
+                text: i18n("Update Interval (minutes)")
             }
 
             TextField {
@@ -59,6 +61,35 @@ Item {
             CheckBox {
                 id: timeFormat24Field 
                 text: i18n("Show Time in 24-hour Format")
+            }
+        }
+
+        ColumnLayout {
+            Label {
+                text: "<br />" + i18n("Panel only, increase default widget size (plasma restart needed)")
+            }
+
+            Row {
+                TextField {
+                    id: widthDeltaField
+                    inputMask: "99"
+                    inputMethodHints: Qt.ImhDigitsOnly
+                }
+                Label {
+                    text: i18n("Increase width by this many grid units")
+                    anchors.verticalCenter: widthDeltaField.verticalCenter
+                }
+            }
+            Row {
+                TextField {
+                    id: heightDeltaField
+                    inputMask: "99"
+                    inputMethodHints: Qt.ImhDigitsOnly
+                }
+                Label {
+                    text: i18n("Increase height by this many grid units")
+                    anchors.verticalCenter: heightDeltaField.verticalCenter
+                }
             }
         }
     }

--- a/plasmoid/contents/ui/Weather.qml
+++ b/plasmoid/contents/ui/Weather.qml
@@ -20,6 +20,22 @@ Item {
     Layout.minimumHeight: units.gridUnit * 20
     clip: true
 
+    //
+    // This only affects the widget size when installed into panel and
+    // allows the widget to be adjusted via user configuration if needed. 
+    // With no adjustment (width/heightDelta set to 0), on some monitors 
+    // text may be cut off at the edges. 
+    // Note: when width/heightDelta configured as 0, implicitWidth/Height
+    // remains undefined and has no effect (this is why string values foo/bar
+    // are added as an intentional type mismatch. This ensures no change from
+    // previous behavior when these configured values remain at default
+    // settings, 0.
+    // A plasmashell restart is needed for width/heightDelta entries to take 
+    // effect.
+    //
+    implicitWidth: Layout.minimumWidth   + (units.gridUnit * ((plasmoid.configuration.widthDelta !== 0) ? plasmoid.configuration.widthDelta : "foo"))
+    implicitHeight: Layout.minimumHeight + (units.gridUnit * ((plasmoid.configuration.heightDelta!== 0) ? plasmoid.configuration.heightDelta : "bar"))
+
     //Yahoo.qml implements the API and stores relevant data
     Yahoo {
         id: backend


### PR DESCRIPTION
Height and width can now be adjusted over the default layout
dimensions to fix text that is possibly cut off at edges since the
pop-up widget has no resize handle (unlike when widget installed on
desktop). This only affects the widget when installed to panel and
not the desktop. Note also that the widget must be restarted to take
effect so the typical user must log-out/in or reboot after changing
the dimensions adjustments.
Final note: When adjustment values are 0, implicitHeight/Width remains
undefined. This causes default adjustments 0 to cause no change
from before this commit since some monitors don't require an
adjustment because they don't exhibit edge cut off. Backward
compatibility is preserved.
