### PR TITLE
Re #59: Set widget dimension so default size fits for panel popup.

### DIFF
--- a/plasmoid/contents/ui/Weather.qml
+++ b/plasmoid/contents/ui/Weather.qml
@@ -16,6 +16,8 @@ import org.kde.plasma.core 2.0 as PlasmaCore
 import org.kde.plasma.components 2.0 as PlasmaComponents
 
 Item {
+    width: units.gridUnit * 26 
+    height: units.gridUnit * 24 
     Layout.minimumWidth: units.gridUnit * 18
     Layout.minimumHeight: units.gridUnit * 20
     clip: true


### PR DESCRIPTION
Adds top level "height:" and "width:" values so that text
in panel pop-up fits inside the box with text at edges not cut
off. Only tested for worst case English text so not sure that the
dimensions are large enough for the various translation texts.
Changes committed:
    modified:   plasmoid/contents/ui/Weather.qml
