### PR TITLE
Re #62: Tray icon immediately shows current conditions at log-in.

### DIFF
--- a/plasmoid/contents/ui/CompactWx.qml
+++ b/plasmoid/contents/ui/CompactWx.qml
@@ -1,0 +1,117 @@
+/*
+ *   Author: Symeon Huang (librehat) <hzwhuang@gmail.com>
+ *   Copyright 2016
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU Library General Public License as
+ *   published by the Free Software Foundation; either version 3 or
+ *   (at your option) any later version.
+ */
+
+import QtQuick 2.2
+import QtQuick.Layouts 1.1
+import QtQuick.Controls 1.2
+import org.kde.plasma.plasmoid 2.0
+import org.kde.plasma.core 2.0 as PlasmaCore
+import org.kde.plasma.components 2.0 as PlasmaComponents
+
+Item {
+
+    //Yahoo.qml implements the API and stores relevant data
+    Yahoo {
+        id: backend
+    }
+    
+    property alias hasdata: backend.hasdata
+    property alias m_isbusy: backend.m_isbusy
+    
+    // Items that appear in tray 
+    Row {
+        anchors { horizontalCenter: parent.horizontalCenter; verticalCenter: parent.verticalCenter }
+
+        PlasmaComponents.Label {
+            text: plasmoid.icon != "weather-none-available" ? backend.m_conditionTemp + "°" 
+                      : ""
+        }
+
+        PlasmaCore.IconItem {
+            id: conditionIcon
+            source: plasmoid.icon //backend.m_conditionIcon
+        }
+
+        PlasmaComponents.Label {
+            text: " " 
+        }
+    }
+
+
+    Row {
+        anchors { horizontalCenter: parent.horizontalCenter; verticalCenter: parent.verticalCenter }
+
+        PlasmaComponents.BusyIndicator {
+            visible: m_isbusy
+            running: m_isbusy
+        }
+    }
+
+    Timer {
+        id: iconUpdater
+        interval: 1000
+        running: m_isbusy
+        repeat: m_isbusy
+        onTriggered: {
+            if(!hasdata) {
+                plasmoid.icon = "weather-none-available"
+                plasmoid.toolTipMainText = i18n("Click tray icon")
+                plasmoid.toolTipSubText = i18n("for error details")
+            }
+            else {
+                plasmoid.icon = backend.m_conditionIcon
+                plasmoid.toolTipMainText = backend.m_city + " " + backend.m_conditionTemp + "°" + backend.m_unitTemperature
+                plasmoid.toolTipSubText = backend.m_conditionDesc
+            }
+        }
+    }
+
+    Timer {
+        id: timer
+        interval: plasmoid.configuration.interval * 60000 //1m=60000ms
+        running: !m_isbusy
+        repeat: true
+        onTriggered: action_reload()
+    }
+    
+    function action_reload () {
+        backend.query()
+        iconUpdater.running = true
+    }
+    
+    Connections {
+        target: plasmoid.configuration
+        onWoeidChanged: action_reload()
+
+        //this signal is emitted when any unit checkbox changes
+        //binding multiple unit changed signals will cause a segfault
+        onMbrChanged: backend.reparse()
+    }
+
+    Component.onCompleted: {
+        action_reload()
+    }
+
+    MouseArea {
+        anchors.fill: parent
+        
+        acceptedButtons: Qt.LeftButton | Qt.MiddleButton
+        
+        hoverEnabled: true
+        
+        onClicked: {
+            if (mouse.button == Qt.MiddleButton) {
+                action_reload() 
+            } else {
+                plasmoid.expanded = !plasmoid.expanded
+            }
+        }
+    }
+}

--- a/plasmoid/contents/ui/Weather.qml
+++ b/plasmoid/contents/ui/Weather.qml
@@ -156,25 +156,6 @@ Item {
     }
 
     Timer {
-        id: iconUpdater
-        interval: 1000
-        running: m_isbusy
-        repeat: m_isbusy
-        onTriggered: {
-            if(!hasdata) {
-                plasmoid.icon = "weather-none-available"
-                plasmoid.toolTipMainText = ""
-                plasmoid.toolTipSubText = ""
-            }
-            else {
-                plasmoid.icon = backend.m_conditionIcon
-                plasmoid.toolTipMainText = backend.m_city + " " + backend.m_conditionTemp + "°" + backend.m_unitTemperature
-                plasmoid.toolTipSubText = backend.m_conditionDesc
-            }
-        }
-    }
-
-    Timer {
         id: timer
         interval: plasmoid.configuration.interval * 60000 //1m=60000ms
         running: !m_isbusy

--- a/plasmoid/contents/ui/main.qml
+++ b/plasmoid/contents/ui/main.qml
@@ -18,4 +18,5 @@ Item {
     //property int formFactor: plasmoid.formFactor
 
     Plasmoid.fullRepresentation: Weather { }
+    Plasmoid.compactRepresentation: CompactWx { }
 }


### PR DESCRIPTION
This also adds the current temperature with the tray icon (with no
F or C units to minimize space). This also adds a prompt to the
tooltip contents to "click on the tray icon for error details"
when there is an error detected (e.g., bad woeid). This will
cause the full representation to appear containing the usual
error display that is not possible to show in the tray.
    NEW file:   plasmoid/contents/ui/CompactWx.qml
    modified:   plasmoid/contents/ui/Weather.qml
    modified:   plasmoid/contents/ui/main.qml
