### PR TITLE
Re #62: Tray icon immediately shows current conditions at log-in.

### DIFF
--- a/plasmoid/contents/ui/CompactWx.qml
+++ b/plasmoid/contents/ui/CompactWx.qml
@@ -1,0 +1,111 @@
+/*
+ *   Author: Symeon Huang (librehat) <hzwhuang@gmail.com>
+ *   Copyright 2016
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU Library General Public License as
+ *   published by the Free Software Foundation; either version 3 or
+ *   (at your option) any later version.
+ */
+
+import QtQuick 2.2
+import QtQuick.Layouts 1.1
+import QtQuick.Controls 1.2
+import org.kde.plasma.plasmoid 2.0
+import org.kde.plasma.core 2.0 as PlasmaCore
+import org.kde.plasma.components 2.0 as PlasmaComponents
+
+Item {
+
+    // Items that appear in tray 
+    Row {
+        anchors { horizontalCenter: parent.horizontalCenter; verticalCenter: parent.verticalCenter }
+
+        PlasmaComponents.Label {
+            text: plasmoid.icon != "weather-none-available" ? backend.m_conditionTemp + "°" 
+                      : ""
+        }
+
+        PlasmaCore.IconItem {
+            id: conditionIcon
+            source: plasmoid.icon //backend.m_conditionIcon
+        }
+
+        PlasmaComponents.Label {
+            text: " " 
+        }
+    }
+
+
+    Row {
+        anchors { horizontalCenter: parent.horizontalCenter; verticalCenter: parent.verticalCenter }
+
+        PlasmaComponents.BusyIndicator {
+            visible: backend.m_isbusy
+            running: backend.m_isbusy
+        }
+    }
+
+    Timer {
+        id: iconUpdater
+        interval: 1000
+        running: backend.m_isbusy
+        repeat: backend.m_isbusy
+        onTriggered: {
+            if(!backend.hasdata) {
+                plasmoid.icon = "weather-none-available"
+                plasmoid.toolTipMainText = i18n("Click tray icon")
+                plasmoid.toolTipSubText = i18n("for error details")
+            }
+            else {
+                plasmoid.icon = backend.m_conditionIcon
+                plasmoid.toolTipMainText = backend.m_city + " " + backend.m_conditionTemp + "°" + backend.m_unitTemperature
+                plasmoid.toolTipSubText = backend.m_conditionDesc
+            }
+        }
+    }
+
+    Timer {
+        id: timer
+        interval: plasmoid.configuration.interval * 60000 //1m=60000ms
+        running: !backend.m_isbusy
+        repeat: true
+        onTriggered: action_reload()
+    }
+    
+    function action_reload () {
+        backend.query()
+        iconUpdater.running = true
+    }
+    
+    Connections {
+        target: plasmoid.configuration
+        onWoeidChanged: action_reload()
+
+        //this signal is emitted when any unit checkbox changes
+        //binding multiple unit changed signals will cause a segfault
+        onMbrChanged: backend.reparse()
+    }
+
+    Component.onCompleted: {
+        if (!backend.haveQueried) {
+            action_reload()
+        }
+    }
+
+    MouseArea {
+        anchors.fill: parent
+        
+        acceptedButtons: Qt.LeftButton | Qt.MiddleButton
+        
+        hoverEnabled: true
+        
+        onClicked: {
+            if (mouse.button == Qt.MiddleButton) {
+                action_reload() 
+            } else {
+                plasmoid.expanded = !plasmoid.expanded
+            }
+        }
+    }
+}

--- a/plasmoid/contents/ui/Weather.qml
+++ b/plasmoid/contents/ui/Weather.qml
@@ -20,20 +20,11 @@ Item {
     Layout.minimumHeight: units.gridUnit * 20
     clip: true
 
-    //Yahoo.qml implements the API and stores relevant data
-    Yahoo {
-        id: backend
-    }
-    
-    property alias hasdata: backend.hasdata
-    property alias errstring: backend.errstring
-    property alias m_isbusy: backend.m_isbusy
-
     //UI block
     PlasmaComponents.Label {
         //top-left
         id: cityname
-        visible: hasdata
+        visible: backend.hasdata
         anchors { top: parent.top; left: parent.left }
         text: "<strong>" + backend.m_city + "</strong><br />" + (backend.m_region ? backend.m_region + ", " : "") + backend.m_country
     }
@@ -49,7 +40,7 @@ Item {
     PlasmaComponents.Label {
         //top-right
         id: yahoo_n_date
-        visible: hasdata
+        visible: backend.hasdata
         anchors { top: parent.top; right: refresh_button.left; rightMargin: units.gridUnit }
         text: backend.m_pubDate + "<br /><a href='" + backend.m_link + "'>" + i18n("YAHOO! Weather") + "</a>"
         horizontalAlignment: Text.AlignRight
@@ -59,7 +50,7 @@ Item {
 
     Row {
         id: conditionRow
-        visible: hasdata
+        visible: backend.hasdata
         anchors.top: yahoo_n_date.bottom
         width: parent.width
         height: width / 3
@@ -97,7 +88,7 @@ Item {
 
     Row {
         id: moredetails
-        visible: hasdata
+        visible: backend.hasdata
         anchors { top: conditionRow.bottom; horizontalCenter: parent.horizontalCenter }
         spacing: Math.max(6, (parent.width - firstDetail.width - secondDetail.width - thirdDetail.width) / 2)
 
@@ -122,7 +113,7 @@ Item {
     
     ListView {
         id: forecastView
-        visible: hasdata
+        visible: backend.hasdata
         anchors { top: moredetails.bottom; topMargin: units.gridUnit; left: parent.left; right: parent.right; bottom: parent.bottom }
         orientation: ListView.Horizontal
         model: backend.dataModel
@@ -137,54 +128,34 @@ Item {
         anchors { horizontalCenter: parent.horizontalCenter; verticalCenter: parent.verticalCenter }
 
         PlasmaCore.IconItem {
-            visible: !(hasdata || m_isbusy)
+            visible: !(backend.hasdata || backend.m_isbusy)
             source: "dialog-error"
             width: theme.mediumIconSize
             height: width
         }
 
         PlasmaComponents.Label {
-            visible: !(hasdata || m_isbusy)
-            text: errstring ? errstring : i18n("Unknown Error.")
+            visible: !(backend.hasdata || backend.m_isbusy)
+            text: backend.errstring ? backend.errstring : i18n("Unknown Error.")
             wrapMode: Text.WordWrap
         }
 
         PlasmaComponents.BusyIndicator {
-            visible: m_isbusy
-            running: m_isbusy
-        }
-    }
-
-    Timer {
-        id: iconUpdater
-        interval: 1000
-        running: m_isbusy
-        repeat: m_isbusy
-        onTriggered: {
-            if(!hasdata) {
-                plasmoid.icon = "weather-none-available"
-                plasmoid.toolTipMainText = ""
-                plasmoid.toolTipSubText = ""
-            }
-            else {
-                plasmoid.icon = backend.m_conditionIcon
-                plasmoid.toolTipMainText = backend.m_city + " " + backend.m_conditionTemp + "°" + backend.m_unitTemperature
-                plasmoid.toolTipSubText = backend.m_conditionDesc
-            }
+            visible: backend.m_isbusy
+            running: backend.m_isbusy
         }
     }
 
     Timer {
         id: timer
         interval: plasmoid.configuration.interval * 60000 //1m=60000ms
-        running: !m_isbusy
+        running: !backend.m_isbusy
         repeat: true
         onTriggered: action_reload()
     }
     
     function action_reload () {
         backend.query()
-        iconUpdater.running = true
     }
     
     Connections {
@@ -197,6 +168,8 @@ Item {
     }
 
     Component.onCompleted: {
-        action_reload()
+        if (!backend.haveQueried) {
+            action_reload()
+        }
     }
 }

--- a/plasmoid/contents/ui/Yahoo.qml
+++ b/plasmoid/contents/ui/Yahoo.qml
@@ -17,6 +17,7 @@ Item {
     //used to display error on widget
     property string errstring
     property bool m_isbusy: false
+    property bool haveQueried: false
 
     property string m_pubDate;
     property string m_link
@@ -72,6 +73,7 @@ Item {
     function query(woeid) {
         console.debug("Querying...")
         
+        haveQueried = true;
         m_isbusy = true
         woeid = woeid ? woeid : plasmoid.configuration.woeid
         if (!woeid) {

--- a/plasmoid/contents/ui/main.qml
+++ b/plasmoid/contents/ui/main.qml
@@ -12,10 +12,17 @@ import QtQuick 2.2
 import org.kde.plasma.plasmoid 2.0
 
 Item {
+
+    //Yahoo.qml implements the API and stores relevant data
+    Yahoo {
+        id: backend
+    }
+
     Plasmoid.switchWidth: units.gridUnit * 12
     Plasmoid.switchHeight: units.gridUnit * 12
 
     //property int formFactor: plasmoid.formFactor
 
     Plasmoid.fullRepresentation: Weather { }
+    Plasmoid.compactRepresentation: CompactWx { }
 }


### PR DESCRIPTION
This also adds the current temperature with the tray icon (with no
F or C units to minimize space), and adds a prompt to the
tooltip contents to "click on the tray icon for error details"
when there is an error detected (e.g., bad woeid). A click on icon will
cause the full representation to appear containing the usual
error display that is not possible to show in the tray.
In addition, "backend" code (Yahoo.qml) is now included at the
main.qml level so only 1 instance of data/api code exists and
onComplete() only does a query if no query has yet occurred, typically
at startup.
    new file:   plasmoid/contents/ui/CompactWx.qml
    modified:   plasmoid/contents/ui/Weather.qml
    modified:   plasmoid/contents/ui/Yahoo.qml
    modified:   plasmoid/contents/ui/main.qml
