### PR TITLE
Re #72: Add an option in settings to set icon style

### DIFF
--- a/plasmoid/contents/config/main.xml
+++ b/plasmoid/contents/config/main.xml
@@ -14,6 +14,9 @@
         <entry name="timeFormat24" type="Bool">
             <default>false</default>
         </entry>
+        <entry name="useWxFonts" type="Bool">
+            <default>false</default>
+        </entry>
         <entry name="celsius" type="Bool">
             <default>true</default>
         </entry>

--- a/plasmoid/contents/ui/CompactWx.qml
+++ b/plasmoid/contents/ui/CompactWx.qml
@@ -22,7 +22,7 @@ Item {
 
     anchors.fill: parent
     property double fontPixelSize: parent.height * 0.7
-    property string fontSymbolStr: FontSymbolTools.getFontCode(plasmoid.icon)
+    property string fontSymbolStr: FontSymbolTools.getFontCode(backend.m_conditionIcon)
 
     // Weather condition icon (actually, a font symbol) in panel 
     PlasmaComponents.Label {
@@ -63,7 +63,7 @@ Item {
 
         visible: backend.hasdata || backend.networkError  || !backend.m_isbusy
 
-        text: plasmoid.icon != "weather-none-available" ? backend.m_conditionTemp + "°" 
+        text: backend.m_conditionIcon != "weather-none-available" ? backend.m_conditionTemp + "°" 
                   : ""
 
         font.pixelSize: fontPixelSize * 0.5 

--- a/plasmoid/contents/ui/ConfigGeneral.qml
+++ b/plasmoid/contents/ui/ConfigGeneral.qml
@@ -20,31 +20,26 @@ Item {
     property alias cfg_woeid: woeidField.text
     property alias cfg_interval: intervalField.text
     property alias cfg_timeFormat24: timeFormat24Field.checked
+    property alias cfg_useWxFonts: useWxFontsField.checked
 
     ColumnLayout {
-        ColumnLayout {
+        RowLayout {
             Label {
                 text: i18n("WOEID")
             }
-
             TextField {
                 id: woeidField
             }
-
-            Label {
-                text: i18n("Visit <a href=\"http://zourbuth.com/tools/woeid/\">Yahoo! WOEID Lookup</a> to find your city's WOEID")
-                onLinkActivated: Qt.openUrlExternally(link)
-            }
+        }
+        Label {
+            text: i18n("Visit <a href=\"http://zourbuth.com/tools/woeid/\">Yahoo! WOEID Lookup</a> to find your city's WOEID") 
+            onLinkActivated: Qt.openUrlExternally(link)
         }
 
-        ColumnLayout {
-            Label {
-                text: " "
-            }
+        RowLayout {
             Label {
                 text: i18n("Update Interval")
             }
-
             TextField {
                 id: intervalField
                 inputMask: "99"
@@ -52,14 +47,16 @@ Item {
             }
         }
 
-        ColumnLayout {
-            Label {
-                text: " "
-            }
-            CheckBox {
-                id: timeFormat24Field 
-                text: i18n("Show Time in 24-hour Format")
-            }
+        CheckBox {
+            id: timeFormat24Field 
+            text: i18n("Show Time in 24-hour Format") 
+        }
+
+        CheckBox {
+            id: useWxFontsField 
+            text: i18n("Use webfont icons instead of KDE theme weather icons") +
+                  "<br\>" + 
+                  i18n("Note: When installed in panel webfont icons are always used")
         }
     }
 }

--- a/plasmoid/contents/ui/Forecast.qml
+++ b/plasmoid/contents/ui/Forecast.qml
@@ -10,6 +10,7 @@
 
 import QtQuick 2.2
 import QtQml.Models 2.1
+import "../code/icons.js" as FontSymbolTools
 
 ListModel {
     ListElement {
@@ -17,5 +18,6 @@ ListModel {
         tempHi: ""
         tempLo: ""
         icon: "weather-none-available"
+        wxFont: 'wi-na'
     }
 }

--- a/plasmoid/contents/ui/ForecastDelegate.qml
+++ b/plasmoid/contents/ui/ForecastDelegate.qml
@@ -23,10 +23,27 @@ Column {
     }
     
     PlasmaCore.IconItem {
+        visible: !plasmoid.configuration.useWxFonts 
         source: icon
         width: theme.smallMediumIconSize
         height: width
         anchors.horizontalCenter: parent.horizontalCenter
+    }
+
+    PlasmaComponents.Label {
+        visible: plasmoid.configuration.useWxFonts 
+        anchors.horizontalCenter: parent.horizontalCenter
+        
+        fontSizeMode: Text.Fit
+        
+        font.family: 'weathericons'
+        text: wxFont 
+        
+        opacity: 1.0 
+        
+        font.pixelSize: height
+        font.weight: Font.Bold
+        font.pointSize: -1
     }
     
     PlasmaComponents.Label {

--- a/plasmoid/contents/ui/Weather.qml
+++ b/plasmoid/contents/ui/Weather.qml
@@ -14,6 +14,7 @@ import QtQuick.Controls 1.2
 import org.kde.plasma.plasmoid 2.0
 import org.kde.plasma.core 2.0 as PlasmaCore
 import org.kde.plasma.components 2.0 as PlasmaComponents
+import "../code/icons.js" as FontSymbolTools
 
 Item {
     width: units.gridUnit * 26 
@@ -80,11 +81,32 @@ Item {
         }
 
         PlasmaCore.IconItem {
+            visible: !plasmoid.configuration.useWxFonts 
             id: conditionIcon
             source: backend.m_conditionIcon
             height: Math.min(conditionCol.height, 256)
             width: height
             anchors.verticalCenter: conditionCol.verticalCenter
+        }
+
+        PlasmaComponents.Label {
+            visible: plasmoid.configuration.useWxFonts 
+            height: parent.height
+            width: height
+            
+            anchors.top: parent.top
+            anchors.topMargin: 0
+
+            fontSizeMode: Text.Fit
+            
+            font.family: 'weathericons'
+            text: FontSymbolTools.getFontCode(backend.m_conditionIcon)
+            
+            opacity: 1.0 
+            
+            font.pixelSize: height
+            font.weight: Font.Bold
+            font.pointSize: -1
         }
     }
 

--- a/plasmoid/contents/ui/Yahoo.qml
+++ b/plasmoid/contents/ui/Yahoo.qml
@@ -9,6 +9,7 @@
 */
 
 import QtQuick 2.2
+import "../code/icons.js" as FontSymbolTools
 
 Item {
     id: yahoo
@@ -263,7 +264,8 @@ Item {
                 "day": parseDay(forecasts[i].day),
                 "tempHi": high + "°" + m_unitTemperature,
                 "tempLo": low  + "°" + m_unitTemperature,
-                "icon": determineIcon(parseInt(forecasts[i].code))
+                "icon": determineIcon(parseInt(forecasts[i].code)),
+                "wxFont": FontSymbolTools.getFontCode(determineIcon(parseInt(forecasts[i].code)))
             })
         }
         console.debug(forecasts.length, "days forecast")
@@ -279,12 +281,12 @@ Item {
         }
     }
 
-    // Call this to set tray icon and tool tips determined by bool
+    // Call this to set panel icon and tool tips determined by bool
     // parameter assigned to hasdata. hasdata only set by this function.
     // This replaces the 1s timer that polled for hasdata when m_isbusy 
     // and serves the same purpose (but with fewer timing issues). 
     // Note: icon and tool tips set here only relevant to compact 
-    // representation (widget installed to tray).
+    // representation (widget installed to panel).
     // Also, used to set m_isbusy if 2nd parameter present.
     //
     function setPlasmoidIconAndTips(has_data, is_busy) {
@@ -294,8 +296,16 @@ Item {
             plasmoid.toolTipSubText = errstring 
         } 
         else {
-            plasmoid.icon = m_conditionIcon
-            plasmoid.toolTipMainText = m_city + " " + m_conditionTemp + "°" + m_unitTemperature
+            // Use either icon from KDE theme or font symbol for tool-tip.
+            if (plasmoid.configuration.useWxFonts) {
+                plasmoid.icon = "" 
+                var fontSymbolStr = FontSymbolTools.getFontCode(m_conditionIcon)
+                plasmoid.toolTipMainText = fontSymbolStr + "  " + m_city + " " +
+                    m_conditionTemp + "°" + m_unitTemperature
+            } else {
+                plasmoid.icon = m_conditionIcon
+                plasmoid.toolTipMainText = m_city + " " + m_conditionTemp + "°" + m_unitTemperature
+            }
             plasmoid.toolTipSubText = m_conditionDesc
         }
         // set these after setting icon since these control icon visibility


### PR DESCRIPTION
This allows selection between KDE theme weather icons or the new font
based icons on the main plasmoid UI (both the large "condition" icon
and the smaller icons for the 10 day forecast.
Note: The new font based icons are _always_ used when installed to panel
and KDE theme weather icons still are not selectable there due to
readability issues.
    modified:   plasmoid/contents/config/main.xml
    modified:   plasmoid/contents/ui/ConfigGeneral.qml
    modified:   plasmoid/contents/ui/Forecast.qml
    modified:   plasmoid/contents/ui/ForecastDelegate.qml
    modified:   plasmoid/contents/ui/Weather.qml
    modified:   plasmoid/contents/ui/Yahoo.qml
