### PR TITLE
Re #74: Security error at zorbuth

### DIFF
--- a/plasmoid/contents/config/main.xml
+++ b/plasmoid/contents/config/main.xml
@@ -5,8 +5,11 @@
      http://www.kde.org/standards/kcfg/1.0/kcfg.xsd">
     <kcfgfile name=""/>
     <group name="com.librehat.yahooweather">
-        <entry name="location" type="String">
-            <default></default>
+        <entry name="locationEntry" type="Bool">
+            <default>true</default>
+        </entry>
+        <entry name="woeidEntry" type="Bool">
+            <default>false</default>
         </entry>
         <entry name="woeid" type="String">
             <default></default>

--- a/plasmoid/contents/config/main.xml
+++ b/plasmoid/contents/config/main.xml
@@ -5,6 +5,9 @@
      http://www.kde.org/standards/kcfg/1.0/kcfg.xsd">
     <kcfgfile name=""/>
     <group name="com.librehat.yahooweather">
+        <entry name="location" type="String">
+            <default></default>
+        </entry>
         <entry name="woeid" type="String">
             <default></default>
         </entry>

--- a/plasmoid/contents/ui/ConfigGeneral.qml
+++ b/plasmoid/contents/ui/ConfigGeneral.qml
@@ -17,39 +17,76 @@ Item {
     width: childrenRect.width
     height: childrenRect.height
 
+    property alias cfg_locationEntry: locationEntry.checked
+    property alias cfg_woeidEntry: woeidEntry.checked
     property alias cfg_woeid: woeidField.text
-    property alias cfg_location: locationField.text
     property alias cfg_interval: intervalField.text
     property alias cfg_timeFormat24: timeFormat24Field.checked
     property alias cfg_useWxFonts: useWxFontsField.checked
+    property bool locChecked: plasmoid.configuration.locationEntry
+    property bool woeChecked: plasmoid.configuration.woeidEntry
+
+    function onLocClicked() {
+        if (woeChecked && plasmoid.configuration.locationEntry) { 
+            cfg_woeid = plasmoid.configuration.woeid
+        } else if (!locChecked) {
+                cfg_woeid = ""
+        }
+        woeChecked = false  
+        locChecked = true
+    }
+
+    function onWoeClicked() {
+        if (locChecked && plasmoid.configuration.woeidEntry) { 
+            cfg_woeid = plasmoid.configuration.woeid
+        } else if (!woeChecked) {
+                cfg_woeid = ""
+        }
+        locChecked = false
+        woeChecked = true
+    }
 
     ColumnLayout {
-        RowLayout {
-            Label {
-                text: i18n("Location")
-            }
-            TextField {
-                id: locationField
+        GroupBox {
+            title: i18n("Select Location or WOEID entry.")
+            flat: true
+            
+            ColumnLayout {
+                ExclusiveGroup {
+                    id: locationOrWoeidGroup
+                }
+
+                RadioButton {
+                    id: locationEntry 
+                    text: i18n("Enter Location below.")
+                    exclusiveGroup: locationOrWoeidGroup
+                    onClicked: onLocClicked() 
+                }
+
+                RadioButton {
+                    id: woeidEntry 
+                    text: i18n("Enter WOEID below.")
+                    exclusiveGroup: locationOrWoeidGroup
+                    onClicked: onWoeClicked() 
+                }
             }
         }
-        Label {
-            text: i18n("Enter location string such as \"London UK\" or a zipcode.") +
-                    "<br\>" +
-                  i18n("Leave Location blank if WOEID usage preferred.")
-        }
         RowLayout {
             Label {
-                text: i18n("WOEID")
+                text: i18n("Location or WOEID")
             }
             TextField {
                 id: woeidField
             }
         }
         Label {
-            text: i18n("Visit <a href=\"http://zourbuth.com/tools/woeid/\">Yahoo! WOEID Lookup</a> to find your city's WOEID (Where On Earth") +
+            text: i18n("If location entry selected above, enter location text such") +
+                    "<br\>" +
+                  i18n("as London,UK or a zipcode. If WOEID entry selected, please") +
+                    "<br\>" +
+                  i18n("visit <a href=\"http://zourbuth.com/tools/woeid/\">Yahoo! WOEID Lookup</a> to find your city's WOEID (Where On Earth") +
                     "<br\>" +
                   i18n("IDentifier) or search the web for other WOEID lookup sites if necessary.")
-            onLinkActivated: Qt.openUrlExternally(link)
         }
 
         RowLayout {
@@ -65,7 +102,7 @@ Item {
 
         CheckBox {
             id: timeFormat24Field 
-            text: i18n("Show Time in 24-hour Format") 
+            text: i18n("Show Time in 24-hour Format.") 
         }
 
         CheckBox {

--- a/plasmoid/contents/ui/ConfigGeneral.qml
+++ b/plasmoid/contents/ui/ConfigGeneral.qml
@@ -18,11 +18,25 @@ Item {
     height: childrenRect.height
 
     property alias cfg_woeid: woeidField.text
+    property alias cfg_location: locationField.text
     property alias cfg_interval: intervalField.text
     property alias cfg_timeFormat24: timeFormat24Field.checked
     property alias cfg_useWxFonts: useWxFontsField.checked
 
     ColumnLayout {
+        RowLayout {
+            Label {
+                text: i18n("Location")
+            }
+            TextField {
+                id: locationField
+            }
+        }
+        Label {
+            text: i18n("Enter location string such as \"London UK\" or a zipcode.") +
+                    "<br\>" +
+                  i18n("Leave Location blank if WOEID usage preferred.")
+        }
         RowLayout {
             Label {
                 text: i18n("WOEID")
@@ -32,7 +46,9 @@ Item {
             }
         }
         Label {
-            text: i18n("Visit <a href=\"http://zourbuth.com/tools/woeid/\">Yahoo! WOEID Lookup</a> to find your city's WOEID") 
+            text: i18n("Visit <a href=\"http://zourbuth.com/tools/woeid/\">Yahoo! WOEID Lookup</a> to find your city's WOEID (Where On Earth") +
+                    "<br\>" +
+                  i18n("IDentifier) or search the web for other WOEID lookup sites if necessary.")
             onLinkActivated: Qt.openUrlExternally(link)
         }
 
@@ -54,9 +70,9 @@ Item {
 
         CheckBox {
             id: useWxFontsField 
-            text: i18n("Use webfont icons instead of KDE theme weather icons") +
+            text: i18n("Use webfont icons instead of KDE theme weather icons.") +
                   "<br\>" + 
-                  i18n("Note: When installed in panel webfont icons are always used")
+                  i18n("Note: When residing in panel webfont icons are always used.")
         }
     }
 }

--- a/plasmoid/contents/ui/ConfigGeneral.qml
+++ b/plasmoid/contents/ui/ConfigGeneral.qml
@@ -73,7 +73,7 @@ Item {
         }
         RowLayout {
             Label {
-                text: i18n("Location or WOEID")
+                text: woeChecked ? i18n("WOEID") : i18n("Location")
             }
             TextField {
                 id: woeidField
@@ -87,6 +87,7 @@ Item {
                   i18n("visit <a href=\"http://zourbuth.com/tools/woeid/\">Yahoo! WOEID Lookup</a> to find your city's WOEID (Where On Earth") +
                     "<br\>" +
                   i18n("IDentifier) or search the web for other WOEID lookup sites if necessary.")
+            onLinkActivated: Qt.openUrlExternally(link)
         }
 
         RowLayout {

--- a/plasmoid/contents/ui/ConfigGeneral.qml
+++ b/plasmoid/contents/ui/ConfigGeneral.qml
@@ -26,22 +26,48 @@ Item {
     property bool locChecked: plasmoid.configuration.locationEntry
     property bool woeChecked: plasmoid.configuration.woeidEntry
 
+    // Respond to click on "Location" radio button. Below "currently"
+    // means immediately before the radio button is clicked.
+    //
     function onLocClicked() {
         if (woeChecked && plasmoid.configuration.locationEntry) { 
-            cfg_woeid = plasmoid.configuration.woeid
-        } else if (!locChecked) {
-                cfg_woeid = ""
+            // woeid radio button is currently selected and entry mode is
+            // still location (new woeid not yet saved). Restore
+            // location string to the text box.
+            woeidField.text = plasmoid.configuration.woeid
+        } else if (woeChecked) {
+            //  woeid radio button is currently selected and entry mode is
+            //  woeid. Clear the text box string. 
+            woeidField.text = "" 
+        } else {
+            // location radio button is currently selected. Don't change
+            // the text box string. 
         }
-        woeChecked = false  
+        // save the checked state for use in the next call to onLocClicked() or
+        // onWoeClicked().
         locChecked = true
+        woeChecked = false  
     }
 
+    // Respond to click on "WOEID" radio button. Below "currently"
+    // means immediately before the radio button is clicked.
+    //
     function onWoeClicked() {
         if (locChecked && plasmoid.configuration.woeidEntry) { 
-            cfg_woeid = plasmoid.configuration.woeid
-        } else if (!woeChecked) {
-                cfg_woeid = ""
+            // location radio button is currently selected and entry mode is
+            // still woeid (new location not yet saved). Restore
+            // woeid string to the text box.
+            woeidField.text = plasmoid.configuration.woeid
+        } else if (locChecked) {
+            //  location radio button is currently selected and entry mode is
+            //  location. Clear the text box string. 
+            woeidField.text = "" 
+        } else {
+            // woeid radio button is currently selected. Don't change the
+            // text box string.
         }
+        // save the checked state for use in the next call to onLocClicked() or
+        // onWoeClicked().
         locChecked = false
         woeChecked = true
     }
@@ -73,6 +99,7 @@ Item {
         }
         RowLayout {
             Label {
+                // Set text field label to match active radio button selection.
                 text: woeChecked ? i18n("WOEID") : i18n("Location")
             }
             TextField {

--- a/plasmoid/contents/ui/Yahoo.qml
+++ b/plasmoid/contents/ui/Yahoo.qml
@@ -81,16 +81,17 @@ Item {
         }
     }
     
-    function query(woeid) {
+    function query() {
         console.debug("Querying...")
         
         haveQueried = true;
         m_isbusy = true
-        woeid = woeid ? woeid : plasmoid.configuration.woeid
-        if (!woeid) {
-            errstring = i18n("Error 3. WOEID is not specified.")
+        var woeid = plasmoid.configuration.woeid.trim()
+        var location = plasmoid.configuration.location.trim()
+        if (!woeid && !location) {
+            errstring = i18n("Error 3. Neither Location or WOEID are configured.")
             setPlasmoidIconAndTips(false, false)
-            console.debug("WOEID is empty.")
+            console.debug("Location/WOEID are empty.")
             return//fail silently
         }
         
@@ -100,7 +101,11 @@ Item {
             unitsymbol = "f"
         }
         
-        var source = "http://query.yahooapis.com/v1/public/yql?q=select * from weather.forecast where woeid='" + woeid + "' and u='f'&format=json"
+        var source
+        if (location)
+            source = "http://query.yahooapis.com/v1/public/yql?q=select * from weather.forecast where woeid in (select woeid from geo.places(1) where text='" + location + "') and u='f'&format=json"
+        else
+            source = "http://query.yahooapis.com/v1/public/yql?q=select * from weather.forecast where woeid='" + woeid + "' and u='f'&format=json"
         console.debug("Source changed to", source)
         doc = new XMLHttpRequest()
         doc.onreadystatechange = function() {
@@ -169,7 +174,7 @@ Item {
             // or corrupted response.
             if (failedAttempts >= 30) {
                 console.debug("query.count =", resObj.query.count)
-                errstring = i18n("Error 2. WOEID may be invalid.")
+                errstring = i18n("Error 2. Location or WOEID may be invalid.")
                 setPlasmoidIconAndTips(false, false)
                 failedAttempts = 0
             } else {
@@ -181,7 +186,7 @@ Item {
         } else if (resObj.query.count !== 1) {
             // count is neither 0 or 1 which is immediately invalid; no retry
             console.debug("query.count not 0 or 1")
-            errstring = i18n("Error 2. WOEID may be invalid.")
+            errstring = i18n("Error 2. Location or WOEID may be invalid.")
             setPlasmoidIconAndTips(false, false)
             return
         }

--- a/plasmoid/contents/ui/Yahoo.qml
+++ b/plasmoid/contents/ui/Yahoo.qml
@@ -86,10 +86,10 @@ Item {
         
         haveQueried = true;
         m_isbusy = true
+        var textIsLocation = plasmoid.configuration.locationEntry
         var woeid = plasmoid.configuration.woeid.trim()
-        var location = plasmoid.configuration.location.trim()
-        if (!woeid && !location) {
-            errstring = i18n("Error 3. Neither Location or WOEID are configured.")
+        if (!woeid) {
+            errstring = i18n("Error 3. The Location/WOEID is not entered.")
             setPlasmoidIconAndTips(false, false)
             console.debug("Location/WOEID are empty.")
             return//fail silently
@@ -102,10 +102,12 @@ Item {
         }
         
         var source
-        if (location)
-            source = "http://query.yahooapis.com/v1/public/yql?q=select * from weather.forecast where woeid in (select woeid from geo.places(1) where text='" + location + "') and u='f'&format=json"
-        else
+        if (textIsLocation) {
+            source = "http://query.yahooapis.com/v1/public/yql?q=select * from weather.forecast where woeid in (select woeid from geo.places(1) where text='" + woeid + "') and u='f'&format=json"
+        } else {
+            // text is WOEID
             source = "http://query.yahooapis.com/v1/public/yql?q=select * from weather.forecast where woeid='" + woeid + "' and u='f'&format=json"
+        }
         console.debug("Source changed to", source)
         doc = new XMLHttpRequest()
         doc.onreadystatechange = function() {
@@ -174,7 +176,7 @@ Item {
             // or corrupted response.
             if (failedAttempts >= 30) {
                 console.debug("query.count =", resObj.query.count)
-                errstring = i18n("Error 2. Location or WOEID may be invalid.")
+                errstring = i18n("Error 2. Location/WOEID may be invalid.")
                 setPlasmoidIconAndTips(false, false)
                 failedAttempts = 0
             } else {
@@ -186,7 +188,7 @@ Item {
         } else if (resObj.query.count !== 1) {
             // count is neither 0 or 1 which is immediately invalid; no retry
             console.debug("query.count not 0 or 1")
-            errstring = i18n("Error 2. Location or WOEID may be invalid.")
+            errstring = i18n("Error 2. Location/WOEID may be invalid.")
             setPlasmoidIconAndTips(false, false)
             return
         }


### PR DESCRIPTION
This adds support for a location string that overrides the WOEID
entry. So now can enter a free form location such as "Pine Crest
TN" or "London, england". Only when location is left blank is the
entered WOEID used in the yahoo query. Otherwise, the location
string (that can also be a zipcode) is used in the query.
Also, added note that a web search can be done to find alternate
sites to obtain WOEID if needed, plus some clean up on configuration
labels (periods at end of sentences, etc.).
    modified:   plasmoid/contents/config/main.xml
    modified:   plasmoid/contents/ui/ConfigGeneral.qml
    modified:   plasmoid/contents/ui/Yahoo.qml
